### PR TITLE
react-router-dom을 사용하여 SPA앱을 구축합니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "6",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import { Global } from '@emotion/react';
 import { ROUTES } from 'constants/route';
 import Home from 'pages/Home/Home';
+import Signin from 'pages/Signin/Signin';
+import Signup from 'pages/Signup/Signup';
 import Todos from 'pages/Todos/Todos';
 import { Route, Routes } from 'react-router-dom';
 import resetCss from 'styles/global';
@@ -11,6 +13,8 @@ const App = () => (
     <Routes>
       <Route path={ROUTES.HOME} element={<Home />} />
       <Route path={ROUTES.TODOS} element={<Todos />} />
+      <Route path={ROUTES.SIGNIN} element={<Signin />} />
+      <Route path={ROUTES.SIGNUP} element={<Signup />} />
     </Routes>
   </div>
 );

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,17 @@
 import { Global } from '@emotion/react';
+import { ROUTES } from 'constants/route';
+import Home from 'pages/Home/Home';
+import Todos from 'pages/Todos/Todos';
+import { Route, Routes } from 'react-router-dom';
 import resetCss from 'styles/global';
 
 const App = () => (
   <div>
-    <Global styles={resetCss}></Global>
+    <Global styles={resetCss} />
+    <Routes>
+      <Route path={ROUTES.HOME} element={<Home />} />
+      <Route path={ROUTES.TODOS} element={<Todos />} />
+    </Routes>
   </div>
 );
 

--- a/src/constants/route.js
+++ b/src/constants/route.js
@@ -1,4 +1,6 @@
 export const ROUTES = {
   HOME: '/',
   TODOS: '/todos',
+  SIGNIN: '/signin',
+  SIGNUP: '/signup',
 };

--- a/src/constants/route.js
+++ b/src/constants/route.js
@@ -1,0 +1,4 @@
+export const ROUTES = {
+  HOME: '/',
+  TODOS: 'todos',
+};

--- a/src/constants/route.js
+++ b/src/constants/route.js
@@ -1,4 +1,4 @@
 export const ROUTES = {
   HOME: '/',
-  TODOS: 'todos',
+  TODOS: '/todos',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from 'App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Home = () => <div>Home</div>;
+
+export default Home;

--- a/src/pages/Signin/Signin.js
+++ b/src/pages/Signin/Signin.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Signin = () => <div>Signin</div>;
+
+export default Signin;

--- a/src/pages/Signup/Signup.js
+++ b/src/pages/Signup/Signup.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Signup = () => <div>Signup</div>;
+
+export default Signup;

--- a/src/pages/Todos/Todos.js
+++ b/src/pages/Todos/Todos.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Todos = () => <div>Todos</div>;
+
+export default Todos;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,7 +1035,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -4914,6 +4914,13 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -7711,6 +7718,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@6:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## 변경사항

-  react-router-dom@6 의존성을 추가합니다.
- BrowserRouter컴포넌트의 children으로 App컴포넌트를 렌더링 시켜줌으로써 프로젝트에서 browser router를 사용할 수 있게 합니다.
- 프로젝트에서 사용되는 라우트를 상수화하여 관리하도록 구현하였습니다.
- src/pages 디렉토리 하위에 Home, Todo를 만들고 각각 `/`, `/todos` 라우트에 접근했을때 렌더링되도로 구현하였습니다.
